### PR TITLE
Improve dashboard focus timing, dark mode polish, and task flow feedback

### DIFF
--- a/app/views/tasks/destroy.turbo_stream.erb
+++ b/app/views/tasks/destroy.turbo_stream.erb
@@ -1,1 +1,3 @@
 <%= turbo_stream.remove dom_id(@task) %>
+<%= turbo_stream.remove dom_id(@task, :mobile) %>
+<%= turbo_stream.remove dom_id(@task, :desktop) %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -68,7 +68,7 @@
           <!-- Mobile: Card layout -->
           <div class="md:hidden divide-y divide-gray-100" id="tasks-list-mobile">
             <% @tasks.each do |task| %>
-              <%= turbo_frame_tag dom_id(task) do %>
+              <%= turbo_frame_tag dom_id(task, :mobile) do %>
                 <div class="p-4 hover:bg-gray-50 transition-colors" style="border-left: 3px solid <%= task.color || '#14b8a6' %>">
                   <div class="flex items-start justify-between gap-2">
                     <div class="flex-1 min-w-0">
@@ -84,14 +84,18 @@
                         <% end %>
                       </div>
                     </div>
-                    <div class="flex items-center gap-1 flex-shrink-0">
+                    <div class="flex items-center gap-2 flex-shrink-0">
                       <% unless task.scheduled_for == Date.current %>
-                        <%= button_to schedule_for_today_task_path(task), method: :post, class: "p-2 text-gray-400 hover:text-green-600 transition-colors touch-manipulation", title: "Add to today" do %>
-                          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                        <%= button_to schedule_for_today_task_path(task), method: :post, form_class: "inline-flex", class: "inline-flex cursor-pointer items-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-100 transition-colors touch-manipulation", title: "Move to Today", aria: { label: "Move task to Today" } do %>
+                          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h4m-2-2v4m-2-2h4m5 6H6a2 2 0 01-2-2V8a2 2 0 012-2h12a2 2 0 012 2v9a2 2 0 01-2 2z"></path></svg>
+                          <span>Today</span>
                         <% end %>
                       <% end %>
-                      <%= link_to edit_task_path(task), data: { turbo_frame: "_top" }, class: "p-2 text-gray-400 hover:text-primary-600 transition-colors touch-manipulation", title: "Edit" do %>
-                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
+                      <%= link_to edit_task_path(task), data: { turbo_frame: "_top" }, class: "inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white p-3 text-gray-500 hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700 transition-colors touch-manipulation", title: "Edit task", aria: { label: "Edit task" } do %>
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
+                      <% end %>
+                      <%= button_to task_path(task), method: :delete, form: { data: { turbo_confirm: "Are you sure you want to delete this task?", turbo_stream: true } }, form_class: "inline-flex", class: "inline-flex cursor-pointer items-center justify-center rounded-lg border border-red-200 bg-red-50 p-3 text-red-500 hover:bg-red-100 hover:text-red-700 transition-colors touch-manipulation", title: "Delete task", aria: { label: "Delete task" } do %>
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
                       <% end %>
                     </div>
                   </div>
@@ -119,7 +123,7 @@
               </thead>
               <tbody class="backlog-table-body divide-y divide-gray-100">
                 <% @tasks.each do |task| %>
-                  <tr class="backlog-table-row hover:bg-gray-50 transition-colors group" id="<%= dom_id(task) %>">
+                  <tr class="backlog-table-row hover:bg-gray-50 transition-colors group" id="<%= dom_id(task, :desktop) %>">
                     <%# Color indicator %>
                     <td class="px-4 py-3">
                       <div class="w-2.5 h-2.5 rounded-full" style="background-color: <%= task.color || '#14b8a6' %>"></div>
@@ -214,17 +218,18 @@
 
                     <%# Actions %>
                     <td class="px-4 py-3 text-right">
-                      <div class="flex items-center justify-end gap-1">
+                      <div class="flex items-center justify-end gap-2">
                         <% unless task.scheduled_for == Date.current %>
-                          <%= button_to schedule_for_today_task_path(task), method: :post, class: "p-1.5 text-gray-400 hover:text-green-600 transition-colors touch-manipulation", title: "Add to today" do %>
-                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                          <%= button_to schedule_for_today_task_path(task), method: :post, form_class: "inline-flex", class: "inline-flex cursor-pointer items-center gap-1.5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-100 transition-colors touch-manipulation", title: "Move to Today", aria: { label: "Move task to Today" } do %>
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h4m-2-2v4m-2-2h4m5 6H6a2 2 0 01-2-2V8a2 2 0 012-2h12a2 2 0 012 2v9a2 2 0 01-2 2z"></path></svg>
+                            <span>Today</span>
                           <% end %>
                         <% end %>
-                        <%= link_to edit_task_path(task), data: { turbo_frame: "_top" }, class: "p-1.5 text-gray-400 hover:text-primary-600 transition-colors touch-manipulation", title: "Edit task" do %>
-                          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
+                        <%= link_to edit_task_path(task), data: { turbo_frame: "_top" }, class: "inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white p-2.5 text-gray-500 hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700 transition-colors touch-manipulation", title: "Edit task", aria: { label: "Edit task" } do %>
+                          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
                         <% end %>
-                        <%= button_to task_path(task), method: :delete, form: { data: { turbo_confirm: "Are you sure you want to delete this task?" } }, class: "p-1.5 text-gray-400 hover:text-red-600 transition-colors touch-manipulation", title: "Delete task" do %>
-                          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
+                        <%= button_to task_path(task), method: :delete, form: { data: { turbo_confirm: "Are you sure you want to delete this task?", turbo_stream: true } }, form_class: "inline-flex", class: "inline-flex cursor-pointer items-center justify-center rounded-lg border border-red-200 bg-red-50 p-2.5 text-red-500 hover:bg-red-100 hover:text-red-700 transition-colors touch-manipulation", title: "Delete task", aria: { label: "Delete task" } do %>
+                          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
                         <% end %>
                       </div>
                     </td>

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class TasksControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:one)
+    @task = tasks(:one)
   end
 
   test "should get new for admin user" do
@@ -17,5 +18,29 @@ class TasksControllerTest < ActionDispatch::IntegrationTest
     get new_task_url
 
     assert_response :success
+  end
+
+  test "backlog renders unique mobile and desktop ids for each task row" do
+    sign_in(@user)
+
+    get tasks_url(view: "list", filter: "all")
+
+    assert_response :success
+    assert_select "#mobile_task_#{@task.id}", count: 1
+    assert_select "#desktop_task_#{@task.id}", count: 1
+    assert_select "#task_#{@task.id}", count: 0
+  end
+
+  test "destroy returns turbo stream removing backlog task from both layouts" do
+    sign_in(@user)
+
+    assert_difference("Task.count", -1) do
+      delete task_url(@task, format: :turbo_stream)
+    end
+
+    assert_response :success
+    assert_equal Mime[:turbo_stream].to_s, response.media_type
+    assert_includes response.body, %(target="mobile_task_#{@task.id}")
+    assert_includes response.body, %(target="desktop_task_#{@task.id}")
   end
 end


### PR DESCRIPTION
## Summary
- Improves dashboard focus-session timing behavior and in-progress task handling, including a cancel action in the task menu.
- Reworks task start feedback by replacing flash messages with countdown toasts for clearer session transitions.
- Adds app-wide light/dark mode toggle support and fixes dashboard/theme styling issues (including dark-mode backlog divider and focus readability updates).
- Updates product messaging across auth and pricing flows, refreshes home marketing screenshots/overlays, and adds/updates What's New announcements.
- Uses distinct mobile vs desktop task IDs for backlog rows to avoid cross-device interaction conflicts.

## Testing
- Manual UI checks captured via Playwright artifacts for dashboard, pricing, auth/session, and home pages.
- Verified dark/light mode toggle behavior and dashboard readability updates across key views.
- Verified task start flow and countdown toast feedback during focus session transitions.
- Verified in-progress task cancel action is available from the dashboard task menu.
- Automated test suite: Not run.